### PR TITLE
Raise when undefined environment variable DEPLOY_SLACK_URL

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -76,6 +76,8 @@ namespace :deploy do
 
   task :cleanup do
     on roles(:app) do
+      raise NameError.new("undefined enviroment variable DEPLOY_SLACK_URL", "ENV['DEPLOY_SLACK_URL']") if fetch(:slack_url).nil?
+
       Slack::Notifier.new(fetch(:slack_url)).post(
         channel: "#syncpod-server",
         username: "deploy",


### PR DESCRIPTION
`ENV['DEPLOY_SLACK_URL']`を忘れたときにわけわからんエラーを吐くみたいなので分かりやすいエラーを吐くように修正しました。