### PR TITLE
通信が1時間なかったらonlineから外すようにした

### DIFF
--- a/app/channels/room_channel.rb
+++ b/app/channels/room_channel.rb
@@ -20,21 +20,25 @@ class RoomChannel < ApplicationCable::Channel
   end
 
   def now_playing_video
+    @subscriber.touch # rubocop:disable Rails/SkipsModelValidations
     RoomChannel.broadcast_to @subscriber.uuid,
                              render_now_playing_video_json(@subscriber.room)
   end
 
   def play_list
+    @subscriber.touch # rubocop:disable Rails/SkipsModelValidations
     RoomChannel.broadcast_to @subscriber.uuid,
                              render_play_list_json(@subscriber.room)
   end
 
   def past_chats
+    @subscriber.touch # rubocop:disable Rails/SkipsModelValidations
     RoomChannel.broadcast_to @subscriber.uuid,
                              render_past_chats_json(@subscriber.room)
   end
 
   def add_video(data)
+    @subscriber.touch # rubocop:disable Rails/SkipsModelValidations
     return if @subscriber.user.blank?
 
     video = @subscriber.room.add_video(data["youtube_video_id"], @subscriber.user)
@@ -48,6 +52,7 @@ class RoomChannel < ApplicationCable::Channel
   end
 
   def exit_force(data)
+    @subscriber.touch # rubocop:disable Rails/SkipsModelValidations
     return if @subscriber.user.blank?
 
     target = User.find(data["user_id"])
@@ -65,6 +70,7 @@ class RoomChannel < ApplicationCable::Channel
   end
 
   def message(data)
+    @subscriber.touch # rubocop:disable Rails/SkipsModelValidations
     return if @subscriber.user.blank?
 
     Chat.create! room: @subscriber.room,

--- a/app/models/user_room_log.rb
+++ b/app/models/user_room_log.rb
@@ -7,7 +7,7 @@ class UserRoomLog < ApplicationRecord
   after_create :send_enter_message
   after_update :send_exit_message, if: proc { |log| log.exit_at_before_last_save.blank? && log.exit_at.present? }
 
-  scope :online, -> { where exit_at: nil }
+  scope :online, -> { where(exit_at: nil).where("updated_at > ?", Time.now.utc - 60 * 60) }
 
   def exit
     update! exit_at: Time.now.utc

--- a/app/models/user_room_log.rb
+++ b/app/models/user_room_log.rb
@@ -7,7 +7,7 @@ class UserRoomLog < ApplicationRecord
   after_create :send_enter_message
   after_update :send_exit_message, if: proc { |log| log.exit_at_before_last_save.blank? && log.exit_at.present? }
 
-  scope :online, -> { where(exit_at: nil).where("updated_at > ?", Time.now.utc - 60 * 60) }
+  scope :online, -> { where(exit_at: nil).where(updated_at: 1.hour.ago..Time.current) }
 
   def exit
     update! exit_at: Time.now.utc

--- a/spec/channels/room_channel_spec.rb
+++ b/spec/channels/room_channel_spec.rb
@@ -4,8 +4,8 @@ describe RoomChannel, type: :channel do
   let(:room) { create(:room) }
   let(:room_key) { room.key }
   let(:user) { create(:user) }
-  let(:log) { subscription.log }
-  let(:target) { RoomChannel.broadcasting_for([RoomChannel.channel_name, log.uuid]) }
+  let(:subscriber) { subscription.subscriber }
+  let(:target) { RoomChannel.broadcasting_for([RoomChannel.channel_name, subscriber.uuid]) }
   let(:stream_from) { "room_" + room.id.to_s }
   let(:current_user) { user }
   before { stub_connection current_user: current_user, ip_address: "0.0.0.0" }
@@ -103,7 +103,7 @@ describe RoomChannel, type: :channel do
     before { subscribe room_key: room.key }
     it { expect { subject }.to change(Chat, :count).by(1) }
     it { expect { subject }.to change { room.online_users.count }.by(-1) }
-    it { expect { subject }.to change { log.exit_at }.from(nil).to(Time) }
+    it { expect { subject }.to change { subscriber.exit_at }.from(nil).to(Time) }
 
     context "without login" do
       let(:current_user) { nil }
@@ -113,7 +113,7 @@ describe RoomChannel, type: :channel do
           to change(Chat, :count).by(0).
                and change { room.online_users.count }.by(0)
       }
-      it { expect { subject }.to change { log.exit_at }.from(nil).to(Time) }
+      it { expect { subject }.to change { subscriber.exit_at }.from(nil).to(Time) }
     end
 
     context "of duplicate subscription" do
@@ -124,7 +124,7 @@ describe RoomChannel, type: :channel do
           to change(Chat, :count).by(0).
                and change { room.online_users.count }.by(0)
       }
-      it { expect { subject }.to change { log.exit_at }.from(nil).to(Time) }
+      it { expect { subject }.to change { subscriber.exit_at }.from(nil).to(Time) }
     end
   end
 

--- a/spec/models/user_room_log_spec.rb
+++ b/spec/models/user_room_log_spec.rb
@@ -5,4 +5,37 @@ describe UserRoomLog, type: :model do
     log = build(:user_room_log)
     expect(log).to be_valid
   end
+
+  describe "#online" do
+    subject { UserRoomLog.online }
+
+    let(:updated_at) { Time.now.utc }
+    let(:log) { create(:user_room_log, exit_at: exit_at, updated_at: updated_at) }
+
+    before { log.save! }
+
+    context "when exit_at is nil" do
+      let(:exit_at) { nil }
+
+      it "returns a log" do
+        expect(subject.size).to eq 1
+      end
+
+      context "and updated_at is out of date" do
+        let(:updated_at) { Time.now.utc - 60 * 60 - 10 }
+
+        it "did not returns a log" do
+          expect(subject.size).to eq 0
+        end
+      end
+    end
+
+    context "when exit_at exsit" do
+      let(:exit_at) { Time.now.utc - 10 }
+
+      it "did not returns a log" do
+        expect(subject.size).to eq 0
+      end
+    end
+  end
 end

--- a/spec/models/user_room_log_spec.rb
+++ b/spec/models/user_room_log_spec.rb
@@ -10,9 +10,8 @@ describe UserRoomLog, type: :model do
     subject { UserRoomLog.online }
 
     let(:updated_at) { Time.now.utc }
-    let(:log) { create(:user_room_log, exit_at: exit_at, updated_at: updated_at) }
 
-    before { log.save! }
+    before { create(:user_room_log, exit_at: exit_at, updated_at: updated_at) }
 
     context "when exit_at is nil" do
       let(:exit_at) { nil }
@@ -30,7 +29,7 @@ describe UserRoomLog, type: :model do
       end
     end
 
-    context "when exit_at exsit" do
+    context "when exit_at exist" do
       let(:exit_at) { Time.now.utc - 10 }
 
       it "did not returns a log" do


### PR DESCRIPTION
action cableでunsubscribeが呼ばれない場合がある

* サーバの再起動やdeployが行われたタイミング
* 長期間通信がなかった場合

通信時にroom_user_logのupdated_atを更新し、それによってonlnieに表示するかしないか切り替えるようにした

懸念点
* テストではupdated_atのchangeを確認できないので、かけてない