### PR TITLE
ページング付きのchat rest apiを用意した

### DIFF
--- a/app/controllers/api/v1/chats_controller.rb
+++ b/app/controllers/api/v1/chats_controller.rb
@@ -5,7 +5,16 @@ class Api::V1::ChatsController < ApplicationController
       render json: { error: t("404 error") }, status: 404
       return
     end
-    cursor = Chat.find_by(id: params[:cursor])
-    @chats = room.past_chats(10, cursor)
+
+    if params[:cursor].present?
+      cursor = Chat.find_by(id: params[:cursor])
+      if cursor.blank?
+        render json: { error: t("404 error") }, status: 404
+        return
+      end
+      @chats = room.past_chats(10, cursor)
+    else
+      @chats = room.past_chats(10)
+    end
   end
 end

--- a/app/controllers/api/v1/chats_controller.rb
+++ b/app/controllers/api/v1/chats_controller.rb
@@ -1,0 +1,10 @@
+class Api::V1::ChatsController < ApplicationController
+  def index
+    room = Room.find_by(key: params[:room_key])
+    if room.blank?
+      render json: { error: t("404 error") }, status: 404
+      return
+    end
+    @chats = room.past_chats(10)
+  end
+end

--- a/app/controllers/api/v1/chats_controller.rb
+++ b/app/controllers/api/v1/chats_controller.rb
@@ -5,6 +5,7 @@ class Api::V1::ChatsController < ApplicationController
       render json: { error: t("404 error") }, status: 404
       return
     end
-    @chats = room.past_chats(10)
+    cursor = Chat.find_by(id: params[:cursor])
+    @chats = room.past_chats(10, cursor)
   end
 end

--- a/app/models/chat.rb
+++ b/app/models/chat.rb
@@ -7,6 +7,10 @@ class Chat < ApplicationRecord
   end
 
   scope :latest_by, ->(num) do
-    order(created_at: :desc).limit(num)
+    order(id: :desc).limit(num)
+  end
+
+  scope :before, ->(cursor) do
+    where("id < ?", cursor)
   end
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -56,8 +56,12 @@ class Room < ApplicationRecord
     videos.ended.order_by_end.last
   end
 
-  def past_chats(num)
-    chats.latest_by(num).reverse
+  def past_chats(num, cursor = nil)
+    if cursor.blank?
+      chats.latest_by(num).reverse
+    else
+      chats.before(cursor).latest_by(num).reverse
+    end
   end
 
   def online_users

--- a/app/views/api/v1/chats/index.json.jbuilder
+++ b/app/views/api/v1/chats/index.json.jbuilder
@@ -1,0 +1,3 @@
+json.chats @chats do |chat|
+  json.partial! "chats/chat", chat: chat
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
           get :recommend
         end
       end
+      resources :chats, only: [:index]
       get "joined_rooms", to: "users#joined_rooms"
       get "youtube/search", to: "youtube#search"
       get "youtube/video", to: "youtube#video"

--- a/spec/channels/room_channel_spec.rb
+++ b/spec/channels/room_channel_spec.rb
@@ -195,8 +195,8 @@ describe RoomChannel, type: :channel do
       before { chat.save! }
       it "expect to have broadcast with chat" do
         expect { subject }.to have_broadcasted_to(target).with { |data|
-                                expect(data).to be_json_eql(%("#{chat.message}")).at_path("data/past_chats/0/message")
-                                expect(data).to be_json_eql(user.id).at_path("data/past_chats/0/user/id")
+                                expect(data).to be_json_eql(%("#{chat.message}")).at_path("data/past_chats/1/message")
+                                expect(data).to be_json_eql(user.id).at_path("data/past_chats/1/user/id")
                               }
       end
     end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -141,6 +141,17 @@ describe Room do
       }
       it { is_expected.to eq [chat2, chat3] }
     end
+
+    context "with cursor" do
+      subject { room.past_chats 2, chat3.id }
+
+      before {
+        chat1.save!
+        chat2.save!
+        chat3.save!
+      }
+      it { is_expected.to eq [chat1, chat2] }
+    end
   end
 
   describe "#online_users" do

--- a/spec/requests/api/v1/chats_spec.rb
+++ b/spec/requests/api/v1/chats_spec.rb
@@ -15,6 +15,18 @@ describe "chats" do
       end
     end
 
+    context "without room_key" do
+      let(:params) { {} }
+
+      it { is_expected.to eq 404 }
+    end
+
+    context "with invalid room_key" do
+      let(:params) { { room_key: "invalid_key" } }
+
+      it { is_expected.to eq 404 }
+    end
+
     context "with cursor" do
       let!(:before_chat) { create(:user_chat, room: room) }
       let(:params) { { room_key: room.key, cursor: before_chat.id } }

--- a/spec/requests/api/v1/chats_spec.rb
+++ b/spec/requests/api/v1/chats_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+describe "chats" do
+  let(:room) { create(:room) }
+
+  describe "GET /api/v1/chats" do
+    let(:params) { { room_key: room.key } }
+    let!(:chat) { create(:user_chat, room: room) }
+
+    context "with valid params" do
+      it "returns a chat", :autodoc do
+        is_expected.to eq 200
+        body = response.body
+        expect(body).to be_json_eql(chat.id).at_path("chats/0/id")
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/chats_spec.rb
+++ b/spec/requests/api/v1/chats_spec.rb
@@ -14,5 +14,22 @@ describe "chats" do
         expect(body).to be_json_eql(chat.id).at_path("chats/0/id")
       end
     end
+
+    context "with cursor" do
+      let!(:before_chat) { create(:user_chat, room: room) }
+      let(:params) { { room_key: room.key, cursor: before_chat.id } }
+
+      it "returns a chat", :autodoc do
+        is_expected.to eq 200
+        body = response.body
+        expect(body).to be_json_eql(chat.id).at_path("chats/0/id")
+      end
+
+      it "dose not contain before_chat" do
+        is_expected.to eq 200
+        body = response.body
+        expect(body).not_to have_json_path("chats/1/id")
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/chats_spec.rb
+++ b/spec/requests/api/v1/chats_spec.rb
@@ -27,8 +27,8 @@ describe "chats" do
       it { is_expected.to eq 404 }
     end
 
-    context "with cursor" do
-      let!(:before_chat) { create(:user_chat, room: room) }
+    context "with valid cursor" do
+      let(:before_chat) { create(:user_chat, room: room) }
       let(:params) { { room_key: room.key, cursor: before_chat.id } }
 
       it "returns a chat", :autodoc do
@@ -42,6 +42,12 @@ describe "chats" do
         body = response.body
         expect(body).not_to have_json_path("chats/1/id")
       end
+    end
+
+    context "with invalid cursor" do
+      let(:params) { { room_key: room.key, cursor: "invalid" } }
+
+      it { is_expected.to eq 404 }
     end
   end
 end


### PR DESCRIPTION
`/api/v1/chats` にroom_keyと前回取得した最後のchat id（cursor）を指定することで、それより前の（cursor自体は含まない）過去チャットが取得できる。
cursorを指定しないときは最新のチャットを取得する

## 検討事項
* websocketの方と合わせるため、並び順が普通と違うのですが、両方BFFで吸収する流れで大丈夫ですか？
* IDでページングするため、ソートをIDに変更したが、問題ないか？